### PR TITLE
Add BOLT draft for gossips extensions

### DIFF
--- a/XXX-gossips-extensions.md
+++ b/XXX-gossips-extensions.md
@@ -1,0 +1,18 @@
+# Staking Credentials -- Gossips Extensions
+
+This document specifies the BOLT 7 Gossips Extensions inside the the Staking Credentials framework.
+
+The message data format, validation algorithms and implementations considerations are laid out.
+
+This draft is version 0.1 of the Gossips Extensions.
+
+## The `credential_policy` message
+
+This gossip message contains informations regarding an Issuer's liquidity collateral acceptance and
+credential policy. It ties a list of asset proofs and credentials to the associated Issuer node key.
+
+## The `contract_policy` message
+
+This gossip message contains informations regarding a Contract's liquidity risk-management policy.
+It ties a list of credential issuers and the covered contracts to the associated Contract Provider
+node key.


### PR DESCRIPTION
This BOLT introduces 2 new types of gossips messages:
- `credentials_policy`
- `contract_policy`

The idea with the new contract_policy, it enables fine-grained risk-management per-type of contracts (e.g dual-funding, liquidity ads) but also a Contract Provider dynamically-accepting multiple credentials. Open question if too much flexibility ?

TODO: cleanup the classic range of extensions.